### PR TITLE
fix(core): ARC-00 fix duplicate namespace & environment in lambda Role Name

### DIFF
--- a/src/aws/lambda/lambda.ts
+++ b/src/aws/lambda/lambda.ts
@@ -74,7 +74,7 @@ export class Lambda extends Construct {
       const role = new CreateLambdaRole(this, "createLambdaRole", {
         namespace,
         environment,
-        name: resourceName,
+        name,
         iamRole: createRole.iamRole,
         iamPolicy: createRole.iamPolicy,
         tags,


### PR DESCRIPTION
fix(core): ARC-00 fix duplicate namespace & environment in lambda Role Name

Fixes #