### PR TITLE
fix(lamba-with-sqs): fixed sqs name

### DIFF
--- a/src/aws/lambdaWithSqs/lambdaWithSqs.ts
+++ b/src/aws/lambdaWithSqs/lambdaWithSqs.ts
@@ -75,7 +75,7 @@ export class LambdaWithSqs extends Construct {
       maxMessageSize,
       messageRetentionSeconds,
       receiveWaitTimeSeconds,
-      name: resourceName,
+      name: !fifoQueue ? resourceName : resourceName + '.fifo',
       policy: JSON.stringify(iamSqsPolicy),
       redrivePolicy: JSON.stringify(redrivePolicy),
       kmsMasterKeyId: kmsMasterKeyId,


### PR DESCRIPTION
sqs name needs to end with '.fifo'
added .fifo extension for fifo sqs.