### PR TITLE
feat(core): Add function response types

### DIFF
--- a/src/aws/lambdaWithSqs/interface.ts
+++ b/src/aws/lambdaWithSqs/interface.ts
@@ -45,4 +45,9 @@ export interface ILambdaWithSqs extends ILambda {
    * Boolean designating a FIFO queue. If not set, it defaults to false making it standard.
    */
   fifoQueue?: boolean;
+
+  /**
+  *  A list of current response type enums applied to the event source mapping for AWS Lambda checkpointing
+  */
+  functionResponseTypes?: string[];
 }

--- a/src/aws/lambdaWithSqs/lambdaWithSqs.ts
+++ b/src/aws/lambdaWithSqs/lambdaWithSqs.ts
@@ -28,6 +28,7 @@ export class LambdaWithSqs extends Construct {
       batchSize,
       createRole,
       tags,
+      functionResponseTypes,
       fifoQueue,
       ...restConfig
     } = config;
@@ -96,6 +97,7 @@ export class LambdaWithSqs extends Construct {
         enabled: true,
         functionName: lambda.arn,
         batchSize,
+        functionResponseTypes,
       }
     );
   }


### PR DESCRIPTION
This update enables the library to support the functionality described here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_event_source_mapping#function_response_types-1,

This feature is particularly valuable for Lambda functions processing batches, where partial errors do not necessitate reprocessing the entire batch. This is especially beneficial when leveraging libraries such as: https://docs.powertools.aws.dev/lambda/typescript/latest/utilities/batch/#required-resources